### PR TITLE
add .babelrc to npmignore to work under React Native

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 !lib
 *~
+.babelrc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kefir.atom",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Reactive variables with Kefir",
   "main": "lib/kefir.atom.js",
   "scripts": {


### PR DESCRIPTION
React Native uses different babel settings