### PR TITLE
Moved kefir to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
   },
   "dependencies": {
     "infestines": "^0.4.4",
-    "kefir": "^3.3.0",
     "partial.lenses": ">=2.2.0"
+  },
+  "peerDependencies": {
+    "kefir": "^3.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-register": "^6.24.1",
     "codecov": "^2.3.0",
     "eslint": "^4.4.1",
+    "kefir": "^3.7.0",
     "kefir.combines": "^4.1.4",
     "mocha": "^3.5.0",
     "nyc": "^11.1.0",


### PR DESCRIPTION
Moved `kefir` to peerDependencies like in other calmm repos (karet, karet.util...) so that you don't end up with multiple different packages of kefir, resulting in failing `instanceof` checks.